### PR TITLE
Rename package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "typed-swagger-tools",
+	"name": "@types/swagger-tools",
 	"version": "0.10.1",
 	"description": "Type definition for [swagger-tools](https://github.com/apigee-127/swagger-tools)",
 	"scripts": {


### PR DESCRIPTION
This way it should be possible to install it via npm and be consumable by tsc@2.
In package.json:
```
"devDependencies": {
   ...
    "@types/swagger-tools": "https://github.com/jzorn/typed-swagger-tools.git",
   ...
}
```